### PR TITLE
Add function name tab completion after SELECT in psql

### DIFF
--- a/doc/src/sgml/ref/psql-ref.sgml
+++ b/doc/src/sgml/ref/psql-ref.sgml
@@ -5231,6 +5231,13 @@ testdb=&gt; \set PROMPT1 '%[%033[1;33;40m%]%n@%/%R%[%033[0m%]%# '
     will fill in the unfinished name, or offer a menu of possible completions
     when there's more than one.  (Depending on the library in use, you may need to
     press <literal>TAB</literal> more than once to get a menu.)
+    Tab completition is also aware of SQL context: for instance, after
+    <command>SELECT</command> it will suggest function names (as well as
+    keywords such as <literal>ALL</literal> and <literal>DISTINCT</literal>),
+    while after <command>FROM</command> it will suggest table names.
+    To avoid overwhelming the list with built-in functions, names from
+    <literal>pg_catalog</literal> are not checked unless the text typed so
+    far begins with <literal>pg_</literal>.
     </para>
 
     <para>

--- a/src/bin/psql/t/010_tab_completion.pl
+++ b/src/bin/psql/t/010_tab_completion.pl
@@ -46,6 +46,7 @@ $node->safe_psql('postgres',
 	  . "CREATE TYPE enum1 AS ENUM ('foo', 'bar', 'baz', 'BLACK');\n"
 	  . "CREATE PUBLICATION some_publication;\n"
 	  . "CREATE TABLE fpo_test (id int4range, valid_at daterange, name text);\n"
+	  . "CREATE FUNCTION tcfunc_test(int) RETURNS int LANGUAGE sql AS 'SELECT 1';\n"
 );
 
 # In a VPATH build, we'll be started in the source directory, but we want
@@ -457,6 +458,22 @@ check_completion("v\t", qr/valid_at /,
 
 check_completion("FR\t", qr/FROM /,
 	"complete FOR PORTION OF <col> FR<tab> to FROM");
+
+clear_query();
+
+# check completion of function names after SELECT
+check_completion(
+	"SELECT tcfunc_te\t",
+	qr/tcfunc_test\b/,
+	"complete function name after SELECT");
+
+clear_query();
+
+# check that pg_ prefix enables system function completion
+check_completion(
+	"SELECT pg_cancel_b\t",
+	qr/pg_cancel_backend\b/,
+	"complete pg_catalog function with pg_ prefix in SELECT");
 
 clear_query();
 

--- a/src/bin/psql/tab-complete.in.c
+++ b/src/bin/psql/tab-complete.in.c
@@ -647,12 +647,14 @@ static const SchemaQuery Query_for_list_of_functions[] = {
 		.viscondition = "pg_catalog.pg_function_is_visible(p.oid)",
 		.namespace = "p.pronamespace",
 		.result = "p.proname",
+		.use_distinct = true,
 	},
 	{
 		.catname = "pg_catalog.pg_proc p",
 		.viscondition = "pg_catalog.pg_function_is_visible(p.oid)",
 		.namespace = "p.pronamespace",
 		.result = "p.proname",
+		.use_distinct = true,
 	}
 };
 
@@ -664,6 +666,7 @@ static const SchemaQuery Query_for_list_of_procedures[] = {
 		.viscondition = "pg_catalog.pg_function_is_visible(p.oid)",
 		.namespace = "p.pronamespace",
 		.result = "p.proname",
+		.use_distinct = true,
 	},
 	{
 		/* not supported in older versions */
@@ -676,6 +679,7 @@ static const SchemaQuery Query_for_list_of_routines = {
 	.viscondition = "pg_catalog.pg_function_is_visible(p.oid)",
 	.namespace = "p.pronamespace",
 	.result = "p.proname",
+	.use_distinct = true,
 };
 
 static const SchemaQuery Query_for_list_of_sequences = {
@@ -5587,6 +5591,12 @@ match_previous_words(int pattern_id,
 			COMPLETE_WITH("'standby_replay'", "'standby_write'", "'standby_flush'", "'primary_flush'");
 	}
 
+/* SELECT -- offer functions and SELECT-list keywords */
+	else if (TailMatches("SELECT") &&
+			 !HeadMatches("GRANT") && !HeadMatches("REVOKE"))
+		COMPLETE_WITH_VERSIONED_SCHEMA_QUERY_PLUS(Query_for_list_of_functions,
+												  "ALL", "DISTINCT", "*");
+
 /* WITH [RECURSIVE] */
 
 	/*
@@ -6162,6 +6172,20 @@ _complete_from_query(const char *simple_query,
 				{
 					appendPQExpBufferStr(&query_buffer,
 										 " AND c.relnamespace <> (SELECT oid FROM"
+										 " pg_catalog.pg_namespace WHERE nspname = 'pg_catalog')");
+				}
+
+				/*
+				 * Similarly, when fetching function names, don't check
+				 * pg_catalog entries unles the input-so-far begins with
+				 * "pg_".
+				 */
+				if (strcmp(schema_query->catname,
+						   "pg_catalog.pg_proc p") == 0 &&
+					strncmp(objectname, "pg_", 3) != 0)
+				{
+					appendPQExpBufferStr(&query_buffer,
+										 " AND p.pronamespace <> (SELECT oid FROM"
 										 " pg_catalog.pg_namespace WHERE nspname = 'pg_catalog')");
 				}
 


### PR DESCRIPTION
Teach psql's tab completion to suggest function names after SELECT. The keywords ALL, DISTINCT, and * are also included since they are the most common non-function tokens that follow SELECT, and omitting them would regress the existing keyword completion in that position.

To keep the completion list manageable, pg_catalog functions are suppressed unless the text typed so far begins with "pg_".  Also add DISTINCT to the function query results to avoid duplicate entries from overloaded functions.

Update the psql documentation to describe the new context-aware completion behavior, and add TAP tests covering both user-defined function completion and pg_catalog prefix filtering.