### PR TITLE
Add regression test for EventTriggerCollectAlterTSConfig with NULL dictIds

### DIFF
--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -2004,8 +2004,11 @@ EventTriggerCollectAlterTSConfig(AlterTSConfigurationStmt *stmt, Oid cfgId,
 	command->in_extension = creating_extension;
 	ObjectAddressSet(command->d.atscfg.address,
 					 TSConfigRelationId, cfgId);
-	command->d.atscfg.dictIds = palloc_array(Oid, ndicts);
-	memcpy(command->d.atscfg.dictIds, dictIds, sizeof(Oid) * ndicts);
+	if (ndicts > 0)
+	{
+		command->d.atscfg.dictIds = palloc_array(Oid, ndicts);
+		memcpy(command->d.atscfg.dictIds, dictIds, sizeof(Oid) * ndicts);
+	}
 	command->d.atscfg.ndicts = ndicts;
 	command->parsetree = (Node *) copyObject(stmt);
 

--- a/src/test/regress/expected/event_trigger.out
+++ b/src/test/regress/expected/event_trigger.out
@@ -817,3 +817,18 @@ NOTICE:  DROP POLICY dropped policy
 CREATE POLICY pguc ON event_trigger_test USING (FALSE);
 SET event_triggers = 'off';
 DROP POLICY pguc ON event_trigger_test;
+-- Test that EventTriggerCollectAlterTSConfig handles DROP MAPPING
+-- with ndicts=0, dictIds=NULL (the DROP MAPPING code path always
+-- passes NULL,0).  Previously crashed under UBSAN due to
+-- memcpy(dest, NULL, 0) being undefined behavior.
+CREATE FUNCTION noop_event_trigger() RETURNS event_trigger
+LANGUAGE plpgsql AS $$ BEGIN END; $$;
+CREATE EVENT TRIGGER noop_event_trigger ON ddl_command_end
+    EXECUTE FUNCTION noop_event_trigger();
+SET event_triggers = 'on';
+CREATE TEXT SEARCH CONFIGURATION evttrig_tscfg (COPY = pg_catalog.simple);
+ALTER TEXT SEARCH CONFIGURATION evttrig_tscfg
+    DROP MAPPING FOR word;
+DROP TEXT SEARCH CONFIGURATION evttrig_tscfg;
+DROP EVENT TRIGGER noop_event_trigger;
+DROP FUNCTION noop_event_trigger;

--- a/src/test/regress/sql/event_trigger.sql
+++ b/src/test/regress/sql/event_trigger.sql
@@ -638,3 +638,21 @@ DROP POLICY pguc ON event_trigger_test;
 CREATE POLICY pguc ON event_trigger_test USING (FALSE);
 SET event_triggers = 'off';
 DROP POLICY pguc ON event_trigger_test;
+
+-- Test that EventTriggerCollectAlterTSConfig handles DROP MAPPING
+-- with ndicts=0, dictIds=NULL (the DROP MAPPING code path always
+-- passes NULL,0).  Previously crashed under UBSAN due to
+-- memcpy(dest, NULL, 0) being undefined behavior.
+CREATE FUNCTION noop_event_trigger() RETURNS event_trigger
+LANGUAGE plpgsql AS $$ BEGIN END; $$;
+CREATE EVENT TRIGGER noop_event_trigger ON ddl_command_end
+    EXECUTE FUNCTION noop_event_trigger();
+SET event_triggers = 'on';
+
+CREATE TEXT SEARCH CONFIGURATION evttrig_tscfg (COPY = pg_catalog.simple);
+ALTER TEXT SEARCH CONFIGURATION evttrig_tscfg
+    DROP MAPPING FOR word;
+
+DROP TEXT SEARCH CONFIGURATION evttrig_tscfg;
+DROP EVENT TRIGGER noop_event_trigger;
+DROP FUNCTION noop_event_trigger;


### PR DESCRIPTION
The DROP MAPPING code path in tsearchcmds.c calls
EventTriggerCollectAlterTSConfig(stmt, cfgId, NULL, 0).  When an event trigger on ddl_command_end is active, this reaches memcpy(dest, NULL, 0) which is undefined behavior.  Under -fsanitize=undefined this crashes the server.

Add a test that exercises this exact code path: a ddl_command_end event trigger combined with ALTER TEXT SEARCH CONFIGURATION ... DROP MAPPING.

Bug latent since b488c580aef (2015).